### PR TITLE
Reimplement heatMap

### DIFF
--- a/R/bayesPO.R
+++ b/R/bayesPO.R
@@ -146,7 +146,7 @@ methods::setMethod("fit_bayesPO",
 
   time <- Sys.time()
   mcmcRun <- list()
-  heatMap <- rep(0, nrow(background))
+  heatMap <- rep(list(rep(0, nrow(background))), chains)
   for (c in 1:chains){
      if (chains > 1 && verbose) cat("Starting chain ", c, ".\n",sep="")
      temp <- runBayesPO(
@@ -184,7 +184,7 @@ methods::setMethod("fit_bayesPO",
       mcmc_setup$thin, # MCMC thin
       mcmc_setup$iter, # MCMC iterations
       cores, verbose)
-     heatMap <- heatMap + temp$xPrimePred
+     heatMap[[c]] <- heatMap[[c]] + temp$xPrimePred
      mcmcRun[[c]] <- do.call(cbind, temp[-length(temp)])
      colnames(mcmcRun[[c]]) <- parnames
      mcmcRun[[c]] <- coda::mcmc(mcmcRun[[c]], thin = mcmc_setup$thin)
@@ -196,7 +196,7 @@ methods::setMethod("fit_bayesPO",
 
   return(methods::new("bayesPO_fit",
                       fit = do.call(coda::mcmc.list, mcmcRun),
-                      # heatMap = heatMap,
+                      heatMap = heatMap,
                       original = object,
                       backgroundSummary = summary(background),
                       area = area,
@@ -249,7 +249,7 @@ methods::setMethod("fit_bayesPO", signature(object = "bayesPO_fit",
 
    time <- Sys.time()
    mcmcRun <- list()
-   # heatMap <- s("heatMap")
+   heatMap <- s("heatMap")
    for (c in 1:chains){
      if (chains > 1 && verbose) cat("Starting chain ",c,".\n",sep="")
      temp <- runBayesPO(
@@ -287,7 +287,7 @@ methods::setMethod("fit_bayesPO", signature(object = "bayesPO_fit",
        mcmc_setup$thin, # MCMC thin
        mcmc_setup$iter, # MCMC iterations
        cores, verbose)
-     # heatMap <- heatMap + temp$xPrimePred
+     heatMap[[c]] <- heatMap[[c]] + temp$xPrimePred
      mcmcRun[[c]] <- do.call(cbind, temp[-length(temp)])
      colnames(mcmcRun[[c]]) <- s("parnames")
      mcmcRun[[c]] <- coda::mcmc(mcmcRun[[c]], thin = mcmc_setup$thin)
@@ -303,7 +303,7 @@ methods::setMethod("fit_bayesPO", signature(object = "bayesPO_fit",
                            coda::mcmc(rbind(s("fit")[[i]],
                                             mcmcRun[[i]])))
                        ),
-                       # heatMap = heatMap,
+                       heatMap = heatMap,
                        original = s("original"),
                        backgroundSummary = s("backgroundSummary"),
                        area = s("area"),

--- a/R/fit-class.R
+++ b/R/fit-class.R
@@ -22,12 +22,15 @@ NULL
 #' covariates with column names, they are replicated here. If they are the
 #' column indexes, names are generated for identification.
 #' @field mcmc_setup The original mcmc setup used.
+#' @field heatMap A list of numeric vectors, where each vector corresponds to a
+#' chain in the MCMC run. Each vector contains the predicted unobserved points,
+#' with values ranging from 0 to the total number of iterations \code{iter}.
 #' @seealso \code{\link{fit_bayesPO}}
 #' @export
 #' @exportClass bayesPO_fit
 methods::setClass("bayesPO_fit",
                   representation(fit = "mcmc.list",
-                                 # heatMap = "numeric",
+                                 heatMap = "list",
                                  original = "bayesPO_model",
                                  backgroundSummary = "table",
                                  area = "numeric",

--- a/src/covariates.h
+++ b/src/covariates.h
@@ -30,6 +30,9 @@ public:
   }
   Eigen::MatrixXd retrieveInt(const Eigen::VectorXi&);
   Eigen::MatrixXd retrieveObs(const Eigen::VectorXi&);
+  void resetUnobservedCounts() {
+    unObservedCounts.setZero();
+  };
 
   // Constructor
   retrievCovs(std::vector<int> si, std::vector<int> so);

--- a/src/runBayesPO.cpp
+++ b/src/runBayesPO.cpp
@@ -69,6 +69,8 @@ Rcpp::List runBayesPO(Eigen::VectorXd beta, Eigen::VectorXd delta,
       progr_Burnin.increment();
       MarkovChain.update();
       }
+    // Reset unObservedCounts after burn-in
+    covs->resetUnobservedCounts();
     t2 = std::chrono::high_resolution_clock::now();
     if (verbose) Rcpp::Rcout << "Warm up complete. ";
     if (verbose) Rcpp::Rcout << "Warmup took " <<


### PR DESCRIPTION
- Implemented heatMap as a list of numeric vectors, with each vector corresponding to a chain in the MCMC run.
- Excluded burn-in phase and reset unobserved counts after MCMC warm-up.
